### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -220,7 +220,7 @@ approach
 <assembly
         xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd">
     <id>stubs</id>
     <formats>
         <format>jar</format>
@@ -291,7 +291,7 @@ approach
 - Add `spring.application.name=car-rental`
 - In `FraudTests` we'll add another test (we need `@AutoConfigureStubRunner`)
     * `@Autowired RestTemplate`
-    * Use the `RestTemplate` to call `"http://fraud-detection/frauds"`
+    * Use the `RestTemplate` to call `"https://fraud-detection/frauds"`
     * The test passes cause SC-Contract redirects the calls via artifact id
 
 ==== Stub Runner Boot with Eureka and Rabbit (optional)

--- a/car-rental/src/main/java/com/example/carrental/CarRentalApplication.java
+++ b/car-rental/src/main/java/com/example/carrental/CarRentalApplication.java
@@ -144,7 +144,7 @@ class CarRentalController {
 	@PostMapping("/rent")
 	@SuppressWarnings("unchecked")
 	ResponseEntity<String> rent(@RequestBody ClientRequest request) {
-		String frauds = restTemplate.getForObject("http://fraud-detection/frauds", String.class);
+		String frauds = restTemplate.getForObject("https://fraud-detection/frauds", String.class);
 		if (frauds.contains(request.getName())) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("NO");
 		}

--- a/car-rental/src/test/java/com/example/carrental/CallingStubInEurekaTests.java
+++ b/car-rental/src/test/java/com/example/carrental/CallingStubInEurekaTests.java
@@ -27,7 +27,7 @@ public class CallingStubInEurekaTests {
 	@Test
 	public void should_retrieve_list_of_frauds_from_stub_via_discovery() {
 		ResponseEntity<String> entity = this.restTemplate.exchange(RequestEntity
-				.get(URI.create("http://fraud-detection/frauds")).build(), String.class);
+				.get(URI.create("https://fraud-detection/frauds")).build(), String.class);
 
 		BDDAssertions.then(entity.getStatusCode().value()).isEqualTo(201);
 		BDDAssertions.then(entity.getBody()).isEqualTo("[\"marcin\",\"josh\"]");

--- a/car-rental/src/test/java/com/example/carrental/FraudTests.java
+++ b/car-rental/src/test/java/com/example/carrental/FraudTests.java
@@ -61,7 +61,7 @@ public class FraudTests {
 	@Test
 	public void should_retrieve_list_of_frauds_from_stub_via_discovery() {
 		ResponseEntity<String> entity = this.restTemplate.exchange(RequestEntity
-				.get(URI.create("http://fraud-detection/frauds")).build(), String.class);
+				.get(URI.create("https://fraud-detection/frauds")).build(), String.class);
 
 		BDDAssertions.then(entity.getStatusCode().value()).isEqualTo(201);
 		BDDAssertions.then(entity.getBody()).isEqualTo("[\"marcin\",\"josh\"]");


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://fraud-detection/frauds (UnknownHostException) with 4 occurrences migrated to:  
  https://fraud-detection/frauds ([https](https://fraud-detection/frauds) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://maven.apache.org/xsd/assembly-1.1.3.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/assembly-1.1.3.xsd ([https](https://maven.apache.org/xsd/assembly-1.1.3.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:6543/fraud with 1 occurrences
* http://localhost:6544/fraud with 1 occurrences
* http://localhost:6544/message with 1 occurrences
* http://localhost:6545/frauds with 1 occurrences
* http://localhost:6545/message with 1 occurrences
* http://localhost:8083/stubs with 1 occurrences
* http://localhost:8083/triggers with 1 occurrences
* http://localhost:8083/triggers/trigger_a_fraud with 1 occurrences
* http://localhost:8761 with 1 occurrences
* http://localhost:8765 with 1 occurrences
* http://localhost:9876/frauds with 2 occurrences
* http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences