### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -220,7 +220,7 @@ approach
 <assembly
         xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd">
     <id>stubs</id>
     <formats>
         <format>jar</format>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://maven.apache.org/xsd/assembly-1.1.3.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/assembly-1.1.3.xsd ([https](https://maven.apache.org/xsd/assembly-1.1.3.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://fraud-detection/frauds with 4 occurrences
* http://localhost:6543/fraud with 1 occurrences
* http://localhost:6544/fraud with 1 occurrences
* http://localhost:6544/message with 1 occurrences
* http://localhost:6545/frauds with 1 occurrences
* http://localhost:6545/message with 1 occurrences
* http://localhost:8083/stubs with 1 occurrences
* http://localhost:8083/triggers with 1 occurrences
* http://localhost:8083/triggers/trigger_a_fraud with 1 occurrences
* http://localhost:8761 with 1 occurrences
* http://localhost:8765 with 1 occurrences
* http://localhost:9876/frauds with 2 occurrences
* http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences